### PR TITLE
Add workshop management and registrations with admin manual return support

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,83 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    function getUserRole() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+    }
+
+    function isAdmin() {
+      return isAuthenticated() && getUserRole() == 'admin';
+    }
+
+    function isLeader() {
+      return isAuthenticated() && getUserRole() == 'leader';
+    }
+
+    function canManageWorkshopRegistrations() {
+      return isAdmin() || isLeader();
+    }
+
+    match /users/{userId} {
+      allow create: if isAuthenticated();
+      allow get: if request.auth.uid == userId;
+      allow list: if isAdmin();
+      allow read: if (isAuthenticated() && request.auth.uid == userId) || isAdmin() || isLeader();
+      allow update: if (isAuthenticated() && request.auth.uid == userId &&
+                        request.resource.data.keys().hasOnly(['displayName', 'email']))
+                    || isAdmin();
+      allow delete: if isAdmin();
+    }
+
+    match /events/{eventId} {
+      allow read: if isAdmin() || isLeader();
+      allow create, update, delete: if isAdmin();
+
+      match /participants/{participantId} {
+        allow read: if isAdmin() || isLeader();
+        allow create, delete: if isAdmin();
+        allow update: if isAdmin() ||
+          (isLeader() && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['location']));
+      }
+
+      match /workshops/{workshopId} {
+        allow read: if isAdmin() || isLeader();
+        allow create, update, delete: if isAdmin();
+      }
+
+      match /workshopRegistrations/{registrationId} {
+        allow read: if isAdmin() || isLeader();
+        allow create, delete: if canManageWorkshopRegistrations();
+        allow update: if false;
+      }
+
+      match /workshopDailyCounts/{countId} {
+        allow read: if isAdmin() || isLeader();
+        allow create, update, delete: if canManageWorkshopRegistrations();
+      }
+    }
+
+    match /activities/{activityId} {
+      allow read: if isAdmin() || isLeader();
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /activityLogs/{logId} {
+      allow read: if isAdmin() || isLeader();
+      allow create: if isAdmin() || isLeader();
+      allow delete: if isAdmin();
+      allow update: if false;
+    }
+
+    match /debug_logs/{logId} {
+      allow create: if true;
+      allow read: if isAdmin();
+      allow update, delete: if false;
+    }
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,6 +30,8 @@ const Header: React.FC = () => {
     .sort((a, b) => b.startDate.getTime() - a.startDate.getTime())[0];
   const activeEventId = activeEvent?.id;
   const scanQrLink = activeEventId ? `/scan/${activeEventId}` : '#';
+  const workshopRegistrationLink = activeEventId ? `/events/${activeEventId}/workshops/register` : '#';
+  const workshopManagementLink = activeEventId ? `/events/${activeEventId}/workshops/manage` : '#';
   const isScanDisabled = !activeEventId;
 
   const handleLogout = async () => {
@@ -72,6 +74,14 @@ const Header: React.FC = () => {
               >
                 Scan QR
               </Link>
+              <Link
+                to={workshopRegistrationLink}
+                className={`border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  isScanDisabled ? 'pointer-events-none opacity-50' : ''
+                }`}
+              >
+                Workshops
+              </Link>
               {isAdmin && (
                 <>
                   <Link
@@ -85,6 +95,14 @@ const Header: React.FC = () => {
                     className="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
                   >
                     Activities
+                  </Link>
+                  <Link
+                    to={workshopManagementLink}
+                    className={`border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                      isScanDisabled ? 'pointer-events-none opacity-50' : ''
+                    }`}
+                  >
+                    Workshop Management
                   </Link>
                   <Link
                     to="/reports"
@@ -210,6 +228,17 @@ const Header: React.FC = () => {
             >
               Scan QR
             </Link>
+            <Link
+              to={workshopRegistrationLink}
+              className={`text-gray-600 hover:bg-gray-50 hover:text-gray-900 block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium ${
+                isScanDisabled ? 'pointer-events-none opacity-50' : ''
+              }`}
+              onClick={() => {
+                if (activeEventId) setIsMenuOpen(false);
+              }}
+            >
+              Workshops
+            </Link>
             {isAdmin && (
               <>
                 <Link
@@ -225,6 +254,17 @@ const Header: React.FC = () => {
                   onClick={() => setIsMenuOpen(false)}
                 >
                   Activities
+                </Link>
+                <Link
+                  to={workshopManagementLink}
+                  className={`text-gray-600 hover:bg-gray-50 hover:text-gray-900 block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium ${
+                    isScanDisabled ? 'pointer-events-none opacity-50' : ''
+                  }`}
+                  onClick={() => {
+                    if (activeEventId) setIsMenuOpen(false);
+                  }}
+                >
+                  Workshop Management
                 </Link>
                 <Link
                   to="/reports"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,12 @@ import ParticipantDetail from './pages/ParticipantDetail';
 import ManageParticipants from './pages/ManageParticipants';
 import ManageEvents from './pages/ManageEvents';
 import ManageActivities from './pages/ManageActivities';
+import ManageWorkshops from './pages/ManageWorkshops';
 import Reports from './pages/Reports';
 import ResetPassword from './pages/ResetPassword';
 import ManageUsers from './pages/ManageUsers';
 import UserProfile from './pages/UserProfile';
+import WorkshopRegistrations from './pages/WorkshopRegistrations';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -34,6 +36,8 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/events" element={<ManageEvents />} />
             <Route path="/events/:eventId" element={<EventDetail />} />
             <Route path="/scan/:eventId" element={<QrScanner />} />
+            <Route path="/events/:eventId/workshops/register" element={<WorkshopRegistrations />} />
+            <Route path="/events/:eventId/workshops/manage" element={<ManageWorkshops />} />
             <Route path="/participants/import/:eventId" element={<ParticipantImport />} />
             <Route path="/events/:eventId/participants/:qrCode" element={<ParticipantDetail />} />
             <Route path="/activities" element={<ManageActivities />} />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, Users, BarChart, Activity, QrCode } from 'lucide-react';
+import { Calendar, Users, BarChart, Activity, QrCode, Ticket } from 'lucide-react';
 import { getEvents } from '../utils/firebase';
 import { Event } from '../types';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/Card';
@@ -36,6 +36,8 @@ const Dashboard: React.FC = () => {
   const activeEvents = events
     .filter((event) => event.active)
     .sort((a, b) => b.startDate.getTime() - a.startDate.getTime());
+  const workshopRegistrationLink = activeEventId ? `/events/${activeEventId}/workshops/register` : '#';
+  const workshopManagementLink = activeEventId ? `/events/${activeEventId}/workshops/manage` : '#';
 
   if (userLoading || loading) {
     return <LoadingSpinner />;
@@ -80,6 +82,23 @@ const Dashboard: React.FC = () => {
             </Link>
           )}
 
+          {['admin', 'leader'].includes(user?.role || '') && (
+            <Link
+              to={workshopRegistrationLink}
+              className={`block ${!activeEventId ? 'pointer-events-none opacity-50' : ''}`}
+            >
+              <Card className="h-full transition-transform hover:shadow-md hover:-translate-y-1">
+                <CardContent className="flex flex-col items-center justify-center p-6">
+                  <Ticket className="mb-4 h-12 w-12 text-orange-500" />
+                  <h3 className="font-medium text-gray-900">Workshop Registrations</h3>
+                  <p className="mt-2 text-center text-sm text-gray-500">
+                    Register participants for workshops by date
+                  </p>
+                </CardContent>
+              </Card>
+            </Link>
+          )}
+
           {user?.role === 'admin' && (
             <>
               <Link to="/participants" className="block">
@@ -101,6 +120,18 @@ const Dashboard: React.FC = () => {
                     <h3 className="font-medium text-gray-900">Manage Activities</h3>
                     <p className="text-sm text-gray-500 text-center mt-2">
                       Create and organize camp activities
+                    </p>
+                  </CardContent>
+                </Card>
+              </Link>
+
+              <Link to={workshopManagementLink} className={`block ${!activeEventId ? 'pointer-events-none opacity-50' : ''}`}>
+                <Card className="h-full transition-transform hover:shadow-md hover:-translate-y-1">
+                  <CardContent className="flex flex-col items-center justify-center p-6">
+                    <Ticket className="mb-4 h-12 w-12 text-rose-500" />
+                    <h3 className="font-medium text-gray-900">Workshop Management</h3>
+                    <p className="mt-2 text-center text-sm text-gray-500">
+                      Configure workshops, dates, and daily capacities
                     </p>
                   </CardContent>
                 </Card>

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link, useLocation } from 'react-router-dom';
-import { Calendar, Users, MapPin, ArrowLeft, RefreshCw } from 'lucide-react';
+import { Calendar, Users, MapPin, RefreshCw, Undo2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Tabs from '../components/ui/Tabs';
 import Badge from '../components/ui/Badge';
+import Modal from '../components/ui/Modal';
 import AuthGuard from '../components/AuthGuard';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { 
@@ -12,14 +13,18 @@ import {
   getActivitiesByEvent,
   getEventById,
   getParticipantsByActivityId,
-  getParticipantsAtCamp
+  getParticipantsAtCamp,
+  createActivityLog,
+  updateParticipantLocation
 } from '../utils/firebase';
 import { Participant, Activity, Event } from '../types';
 import { formatDate } from '../utils/helpers';
+import { useUser } from '../context/UserContext';
 
 
 const EventDetail: React.FC = () => {
   const { eventId } = useParams<{ eventId: string }>();
+  const { user } = useUser();
   const [event, setEvent] = useState<Event | null>(null);
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [activities, setActivities] = useState<Activity[]>([]);
@@ -32,6 +37,10 @@ const EventDetail: React.FC = () => {
   const [selectedActivityParticipants, setSelectedActivityParticipants] = useState<Participant[]>([]);
   const [selectedActivityName, setSelectedActivityName] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [manualReturnParticipant, setManualReturnParticipant] = useState<Participant | null>(null);
+  const [manualReturnActivity, setManualReturnActivity] = useState<Activity | null>(null);
+  const [isManualReturning, setIsManualReturning] = useState(false);
+  const isAdmin = user?.role === 'admin';
 
   const normalize = (s: string) => s.trim().toLowerCase();
   const matchesSearch = (p: Participant) =>
@@ -48,6 +57,12 @@ const EventDetail: React.FC = () => {
     setModalVisible(false);
     setSelectedActivityParticipants([]);
     setSelectedActivityName(null);
+  };
+
+  const closeManualReturnModal = () => {
+    if (isManualReturning) return;
+    setManualReturnParticipant(null);
+    setManualReturnActivity(null);
   };
 
   useEffect(() => {
@@ -133,6 +148,32 @@ const EventDetail: React.FC = () => {
       setParticipantsByActivity(byActivityData);
     } catch (error) {
       console.error('Error refreshing live data:', error);
+    }
+  };
+
+  const handleManualReturn = async () => {
+    if (!eventId || !user?.id || !manualReturnParticipant || !manualReturnActivity) {
+      return;
+    }
+
+    setIsManualReturning(true);
+    try {
+      await createActivityLog({
+        eventId,
+        participantId: manualReturnParticipant.id,
+        activityId: manualReturnActivity.id,
+        leaderId: user.id,
+        type: 'return',
+      });
+
+      await updateParticipantLocation(eventId, manualReturnParticipant.id, null);
+      await refreshLiveData();
+      closeManualReturnModal();
+    } catch (error) {
+      console.error('Error manually checking participant back in:', error);
+      alert('Failed to manually check the participant back in.');
+    } finally {
+      setIsManualReturning(false);
     }
   };
 
@@ -280,9 +321,25 @@ const EventDetail: React.FC = () => {
                               <p className="font-medium">{participant.name}</p>
                               <p className="text-sm text-gray-500">{participant.church}</p>
                             </div>
-                            <Badge variant={participant.type === 'student' ? 'primary' : 'secondary'}>
-                              {participant.type}
-                            </Badge>
+                            <div className="flex items-center space-x-2">
+                              {isAdmin && (
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setManualReturnParticipant(participant);
+                                    setManualReturnActivity(activity);
+                                  }}
+                                  className="rounded-full p-1 text-gray-400 transition-colors hover:text-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-1"
+                                  title="Manually check back in"
+                                  aria-label={`Manually check ${participant.name} back in`}
+                                >
+                                  <Undo2 className="h-4 w-4" />
+                                </button>
+                              )}
+                              <Badge variant={participant.type === 'student' ? 'primary' : 'secondary'}>
+                                {participant.type}
+                              </Badge>
+                            </div>
                           </div>
                         ))}
                       </div>
@@ -469,6 +526,30 @@ const EventDetail: React.FC = () => {
           </div>
         </div>
       )}
+
+      <Modal
+        isOpen={!!manualReturnParticipant && !!manualReturnActivity}
+        onClose={closeManualReturnModal}
+        title="Confirm Manual Check-In"
+      >
+        <div className="space-y-4 pt-4">
+          <p className="text-sm text-gray-700">
+            {manualReturnParticipant?.name} will be manually checked back in to camp and removed from{' '}
+            {manualReturnActivity?.name}.
+          </p>
+          <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+            Only confirm this when you are sure the participant already returned and the QR scan was missed.
+          </p>
+          <div className="flex justify-end space-x-3">
+            <Button variant="outline" onClick={closeManualReturnModal} disabled={isManualReturning}>
+              Cancel
+            </Button>
+            <Button onClick={handleManualReturn} disabled={isManualReturning}>
+              {isManualReturning ? 'Checking In...' : 'Confirm Check-In'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
     </AuthGuard>
   );

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -15,7 +15,7 @@ import {
   updateWorkshop,
 } from '../utils/firebase';
 import { Event, Workshop } from '../types';
-import { formatDate } from '../utils/helpers';
+import { CURRENT_DATE_REFERENCE, formatDate, formatDateKey } from '../utils/helpers';
 
 const toDateInputValue = (date: Date) => {
   const year = date.getFullYear();
@@ -46,6 +46,7 @@ const ManageWorkshops: React.FC = () => {
   const [confirmText, setConfirmText] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+  const todayKey = formatDateKey(CURRENT_DATE_REFERENCE);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -254,13 +255,16 @@ const ManageWorkshops: React.FC = () => {
               value={editAvailableFrom}
               onChange={(event) => setEditAvailableFrom(event.target.value)}
               className="w-full rounded border p-2"
+              min={todayKey}
             />
             <input
               type="date"
               value={editAvailableTo}
               onChange={(event) => setEditAvailableTo(event.target.value)}
               className="w-full rounded border p-2"
+              min={editAvailableFrom || todayKey}
             />
+            <label className="block text-sm font-medium text-gray-700">Daily registration limit</label>
             <input
               type="number"
               min="1"
@@ -325,20 +329,6 @@ const ManageWorkshops: React.FC = () => {
           <>
             <Card>
               <CardHeader>
-                <CardTitle>Workshop Registration Cleanup</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-sm text-gray-600">
-                  Delete all workshop registrations for <span className="font-medium">{activeEvent.name}</span> to reset testing data.
-                </p>
-                <Button variant="danger" onClick={handleClearRegistrations}>
-                  Delete All Workshop Registrations
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
                 <CardTitle>Add Workshop</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -357,6 +347,7 @@ const ManageWorkshops: React.FC = () => {
                       value={availableFrom}
                       onChange={(event) => setAvailableFrom(event.target.value)}
                       className="w-full rounded border p-2"
+                      min={todayKey}
                     />
                   </div>
                   <div className="space-y-2">
@@ -366,17 +357,21 @@ const ManageWorkshops: React.FC = () => {
                       value={availableTo}
                       onChange={(event) => setAvailableTo(event.target.value)}
                       className="w-full rounded border p-2"
+                      min={availableFrom || todayKey}
                     />
                   </div>
                 </div>
-                <input
-                  type="number"
-                  min="1"
-                  value={maxRegistrationsPerDay}
-                  onChange={(event) => setMaxRegistrationsPerDay(event.target.value)}
-                  placeholder="Max registrations per day"
-                  className="w-full rounded border p-2"
-                />
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Daily registration limit</label>
+                  <input
+                    type="number"
+                    min="1"
+                    value={maxRegistrationsPerDay}
+                    onChange={(event) => setMaxRegistrationsPerDay(event.target.value)}
+                    placeholder="Max registrations per day"
+                    className="w-full rounded border p-2"
+                  />
+                </div>
                 <Button onClick={handleAdd}>Add Workshop</Button>
               </CardContent>
             </Card>
@@ -457,6 +452,20 @@ const ManageWorkshops: React.FC = () => {
                 ) : (
                   <p className="text-sm text-gray-600">No workshops found.</p>
                 )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Workshop Registration Cleanup</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Delete all workshop registrations for <span className="font-medium">{activeEvent.name}</span> to reset testing data.
+                </p>
+                <Button variant="danger" onClick={handleClearRegistrations}>
+                  Delete All Workshop Registrations
+                </Button>
               </CardContent>
             </Card>
           </>

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -11,6 +11,7 @@ import {
   createWorkshop,
   deleteWorkshop,
   getEventById,
+  setWorkshopDateLockForEvent,
   subscribeToWorkshopsByEvent,
   updateWorkshop,
 } from '../utils/firebase';
@@ -47,6 +48,7 @@ const ManageWorkshops: React.FC = () => {
   const [message, setMessage] = useState<string | null>(null);
   const [messageType, setMessageType] = useState<'success' | 'error'>('success');
   const todayKey = formatDateKey(CURRENT_DATE_REFERENCE);
+  const isDateSelectionLocked = workshops.length > 0 && workshops.every((workshop) => workshop.lockRegistrationDateToToday);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -140,6 +142,7 @@ const ManageWorkshops: React.FC = () => {
         availableFrom: fromDate,
         availableTo: toDate,
         maxRegistrationsPerDay: Number(maxRegistrationsPerDay),
+        lockRegistrationDateToToday: isDateSelectionLocked,
         active: true,
       });
       resetCreateForm();
@@ -329,6 +332,46 @@ const ManageWorkshops: React.FC = () => {
           <>
             <Card>
               <CardHeader>
+                <CardTitle>Registration Date Mode</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Current mode: <span className="font-medium">{isDateSelectionLocked ? 'Locked to current date' : 'Date can be selected manually'}</span>
+                </p>
+                <Button
+                  variant={isDateSelectionLocked ? 'outline' : 'secondary'}
+                  disabled={workshops.length === 0}
+                  onClick={async () => {
+                    if (!activeEvent || workshops.length === 0) {
+                      return;
+                    }
+
+                    try {
+                      await setWorkshopDateLockForEvent(activeEvent.id, !isDateSelectionLocked);
+                      showMessage(
+                        isDateSelectionLocked
+                          ? 'Workshop registration date can now be selected manually.'
+                          : 'Workshop registration date is now locked to the current date.',
+                        'success'
+                      );
+                    } catch (error) {
+                      console.error('Error updating workshop date mode:', error);
+                      showMessage('Failed to update the registration date mode.', 'error');
+                    }
+                  }}
+                >
+                  {isDateSelectionLocked ? 'Allow Manual Date Selection' : 'Lock Registration to Current Date'}
+                </Button>
+                {workshops.length === 0 && (
+                  <p className="text-sm text-gray-500">
+                    Create at least one workshop before changing the registration date mode.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
                 <CardTitle>Add Workshop</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -436,7 +479,7 @@ const ManageWorkshops: React.FC = () => {
                               {formatDate(workshop.availableFrom)} - {formatDate(workshop.availableTo)}
                             </p>
                             <p className="text-sm text-gray-500">
-                              Max per day: {workshop.maxRegistrationsPerDay} | Status: {workshop.active ? 'Active' : 'Inactive'}
+                              Max per day: {workshop.maxRegistrationsPerDay} | Status: {workshop.active ? 'Active' : 'Inactive'} | Date mode: {workshop.lockRegistrationDateToToday ? 'Current date only' : 'Manual'}
                             </p>
                           </div>
                         </div>

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -1,0 +1,469 @@
+import React, { useEffect, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { useParams } from 'react-router-dom';
+import AuthGuard from '../components/AuthGuard';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import Modal from '../components/ui/Modal';
+import LoadingSpinner from '../components/LoadingSpinner';
+import {
+  clearWorkshopRegistrations,
+  createWorkshop,
+  deleteWorkshop,
+  getEventById,
+  subscribeToWorkshopsByEvent,
+  updateWorkshop,
+} from '../utils/firebase';
+import { Event, Workshop } from '../types';
+import { formatDate } from '../utils/helpers';
+
+const toDateInputValue = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const ManageWorkshops: React.FC = () => {
+  const { eventId } = useParams<{ eventId: string }>();
+  const [activeEvent, setActiveEvent] = useState<Event | null>(null);
+  const [workshops, setWorkshops] = useState<Workshop[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [availableFrom, setAvailableFrom] = useState('');
+  const [availableTo, setAvailableTo] = useState('');
+  const [maxRegistrationsPerDay, setMaxRegistrationsPerDay] = useState('1');
+  const [editWorkshop, setEditWorkshop] = useState<Workshop | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editAvailableFrom, setEditAvailableFrom] = useState('');
+  const [editAvailableTo, setEditAvailableTo] = useState('');
+  const [editMaxRegistrationsPerDay, setEditMaxRegistrationsPerDay] = useState('1');
+  const [editActive, setEditActive] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [bulkAction, setBulkAction] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<() => void>(() => {});
+  const [confirmText, setConfirmText] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        if (!eventId) {
+          setActiveEvent(null);
+          return;
+        }
+
+        const event = await getEventById(eventId);
+        if (!event.active) {
+          setActiveEvent(null);
+          return;
+        }
+
+        setActiveEvent(event);
+
+        unsubscribe = subscribeToWorkshopsByEvent(event.id, (liveWorkshops) => {
+            const sorted = [...liveWorkshops].sort((a, b) => a.name.localeCompare(b.name));
+            setWorkshops(sorted);
+        });
+      } catch (error) {
+        console.error('Error loading workshops:', error);
+        showMessage('Failed to load workshops.', 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [eventId]);
+
+  const showMessage = (text: string, type: 'success' | 'error' = 'success') => {
+    setMessage(text);
+    setMessageType(type);
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  const resetCreateForm = () => {
+    setName('');
+    setAvailableFrom('');
+    setAvailableTo('');
+    setMaxRegistrationsPerDay('1');
+  };
+
+  const openConfirmModal = (text: string, onConfirm: () => void) => {
+    setConfirmText(text);
+    setConfirmAction(() => onConfirm);
+    setModalOpen(true);
+  };
+
+  const openEditModal = (workshop: Workshop) => {
+    setEditWorkshop(workshop);
+    setEditName(workshop.name);
+    setEditAvailableFrom(toDateInputValue(workshop.availableFrom));
+    setEditAvailableTo(toDateInputValue(workshop.availableTo));
+    setEditMaxRegistrationsPerDay(String(workshop.maxRegistrationsPerDay));
+    setEditActive(workshop.active);
+  };
+
+  const handleAdd = async () => {
+    if (!activeEvent || !name || !availableFrom || !availableTo) {
+      return;
+    }
+
+    const fromDate = new Date(`${availableFrom}T00:00:00`);
+    const toDate = new Date(`${availableTo}T00:00:00`);
+
+    if (fromDate.getTime() > toDate.getTime()) {
+      showMessage('The start date must be before or equal to the end date.', 'error');
+      return;
+    }
+
+    if (workshops.some((workshop) => workshop.name.trim().toLowerCase() === name.trim().toLowerCase())) {
+      showMessage('A workshop with that name already exists.', 'error');
+      return;
+    }
+
+    try {
+      await createWorkshop(activeEvent.id, {
+        name: name.trim(),
+        availableFrom: fromDate,
+        availableTo: toDate,
+        maxRegistrationsPerDay: Number(maxRegistrationsPerDay),
+        active: true,
+      });
+      resetCreateForm();
+      showMessage('Workshop created!', 'success');
+    } catch (error) {
+      console.error('Error creating workshop:', error);
+      showMessage('Failed to create workshop.', 'error');
+    }
+  };
+
+  const handleDelete = (workshop: Workshop) => {
+    if (!activeEvent) {
+      return;
+    }
+
+    openConfirmModal(
+      `Are you sure you want to delete ${workshop.name}? Its registrations and daily counts will also be deleted.`,
+      async () => {
+        try {
+          await deleteWorkshop(activeEvent.id, workshop.id);
+          showMessage('Workshop deleted.', 'success');
+        } catch (error) {
+          console.error('Error deleting workshop:', error);
+          showMessage('Failed to delete workshop.', 'error');
+        }
+        setModalOpen(false);
+      }
+    );
+  };
+
+  const handleBulkAction = () => {
+    if (!activeEvent || bulkAction !== 'delete' || selectedIds.length === 0) {
+      return;
+    }
+
+    openConfirmModal(
+      `Are you sure you want to delete ${selectedIds.length} selected workshop${selectedIds.length > 1 ? 's' : ''}? Their registrations and daily counts will also be deleted.`,
+      async () => {
+        try {
+          for (const workshopId of selectedIds) {
+            await deleteWorkshop(activeEvent.id, workshopId);
+          }
+          setSelectedIds([]);
+          setBulkAction('');
+          showMessage('Selected workshops deleted.', 'success');
+        } catch (error) {
+          console.error('Error deleting workshops:', error);
+          showMessage('Failed to delete some workshops.', 'error');
+        }
+        setModalOpen(false);
+      }
+    );
+  };
+
+  const handleClearRegistrations = () => {
+    if (!activeEvent) {
+      return;
+    }
+
+    openConfirmModal(
+      'Are you sure you want to delete all workshop registrations for the active event? This is intended for test cleanup.',
+      async () => {
+        try {
+          await clearWorkshopRegistrations(activeEvent.id);
+          showMessage('All workshop registrations were deleted.', 'success');
+        } catch (error) {
+          console.error('Error clearing workshop registrations:', error);
+          showMessage('Failed to clear workshop registrations.', 'error');
+        }
+        setModalOpen(false);
+      }
+    );
+  };
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <AuthGuard requiredRole="admin">
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-gray-900">Manage Workshops</h1>
+
+        {message && (
+          <div className={`fixed top-6 left-1/2 z-50 -translate-x-1/2 rounded-md border px-4 py-2 text-sm shadow-lg transition-opacity duration-300 ${
+            messageType === 'success'
+              ? 'border-green-300 bg-green-50 text-green-800'
+              : 'border-red-300 bg-red-50 text-red-800'
+          }`}>
+            {message}
+          </div>
+        )}
+
+        <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} title="Confirm">
+          <p>{confirmText}</p>
+          <div className="mt-4 flex space-x-3">
+            <Button variant="outline" onClick={() => setModalOpen(false)}>Cancel</Button>
+            <Button variant="danger" onClick={confirmAction}>Confirm</Button>
+          </div>
+        </Modal>
+
+        <Modal isOpen={!!editWorkshop} onClose={() => setEditWorkshop(null)} title="Edit Workshop">
+          <div className="space-y-4">
+            <input
+              type="text"
+              value={editName}
+              onChange={(event) => setEditName(event.target.value)}
+              className="mt-4 w-full rounded border p-2"
+              placeholder="Workshop name"
+            />
+            <input
+              type="date"
+              value={editAvailableFrom}
+              onChange={(event) => setEditAvailableFrom(event.target.value)}
+              className="w-full rounded border p-2"
+            />
+            <input
+              type="date"
+              value={editAvailableTo}
+              onChange={(event) => setEditAvailableTo(event.target.value)}
+              className="w-full rounded border p-2"
+            />
+            <input
+              type="number"
+              min="1"
+              value={editMaxRegistrationsPerDay}
+              onChange={(event) => setEditMaxRegistrationsPerDay(event.target.value)}
+              className="w-full rounded border p-2"
+              placeholder="Max registrations per day"
+            />
+            <label className="flex items-center space-x-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={editActive}
+                onChange={(event) => setEditActive(event.target.checked)}
+              />
+              <span>Workshop is active</span>
+            </label>
+            <div className="flex justify-end space-x-2">
+              <Button variant="outline" onClick={() => setEditWorkshop(null)}>Cancel</Button>
+              <Button
+                onClick={async () => {
+                  if (!activeEvent || !editWorkshop || !editName || !editAvailableFrom || !editAvailableTo) {
+                    return;
+                  }
+
+                  const fromDate = new Date(`${editAvailableFrom}T00:00:00`);
+                  const toDate = new Date(`${editAvailableTo}T00:00:00`);
+
+                  if (fromDate.getTime() > toDate.getTime()) {
+                    showMessage('The start date must be before or equal to the end date.', 'error');
+                    return;
+                  }
+
+                  try {
+                    await updateWorkshop(activeEvent.id, editWorkshop.id, {
+                      name: editName.trim(),
+                      availableFrom: fromDate,
+                      availableTo: toDate,
+                      maxRegistrationsPerDay: Number(editMaxRegistrationsPerDay),
+                      active: editActive,
+                    });
+                    setEditWorkshop(null);
+                    showMessage('Workshop updated.', 'success');
+                  } catch (error) {
+                    console.error('Error updating workshop:', error);
+                    showMessage('Failed to update workshop.', 'error');
+                  }
+                }}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        </Modal>
+
+        {!activeEvent ? (
+          <Card>
+            <CardContent className="p-6">
+              <p className="text-sm text-gray-600">No active event is available right now.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>Workshop Registration Cleanup</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Delete all workshop registrations for <span className="font-medium">{activeEvent.name}</span> to reset testing data.
+                </p>
+                <Button variant="danger" onClick={handleClearRegistrations}>
+                  Delete All Workshop Registrations
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Add Workshop</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Workshop name"
+                  className="w-full rounded border p-2"
+                />
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-gray-700">Available from</label>
+                    <input
+                      type="date"
+                      value={availableFrom}
+                      onChange={(event) => setAvailableFrom(event.target.value)}
+                      className="w-full rounded border p-2"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-gray-700">Available to</label>
+                    <input
+                      type="date"
+                      value={availableTo}
+                      onChange={(event) => setAvailableTo(event.target.value)}
+                      className="w-full rounded border p-2"
+                    />
+                  </div>
+                </div>
+                <input
+                  type="number"
+                  min="1"
+                  value={maxRegistrationsPerDay}
+                  onChange={(event) => setMaxRegistrationsPerDay(event.target.value)}
+                  placeholder="Max registrations per day"
+                  className="w-full rounded border p-2"
+                />
+                <Button onClick={handleAdd}>Add Workshop</Button>
+              </CardContent>
+            </Card>
+
+            <div className="flex items-center space-x-3">
+              <select
+                value={bulkAction}
+                onChange={(event) => setBulkAction(event.target.value)}
+                className="rounded-md border border-gray-300 p-2 text-sm"
+              >
+                <option value="">Bulk Actions</option>
+                <option value="delete">Delete Selected</option>
+              </select>
+              <Button
+                variant="danger"
+                disabled={selectedIds.length === 0 || !bulkAction}
+                onClick={handleBulkAction}
+              >
+                Apply
+              </Button>
+            </div>
+
+            <Card>
+              <CardHeader className="flex items-center space-x-3">
+                <input
+                  type="checkbox"
+                  checked={workshops.length > 0 && selectedIds.length === workshops.length}
+                  onChange={(event) => {
+                    if (event.target.checked) {
+                      setSelectedIds(workshops.map((workshop) => workshop.id));
+                    } else {
+                      setSelectedIds([]);
+                    }
+                  }}
+                  className="h-4 w-4"
+                />
+                <CardTitle>All Workshops</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {workshops.length > 0 ? (
+                  <div className="space-y-2">
+                    {workshops.map((workshop) => (
+                      <div
+                        key={workshop.id}
+                        className="flex items-center justify-between rounded-md border border-gray-200 bg-white p-3 hover:bg-gray-50"
+                      >
+                        <div className="flex items-center space-x-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(workshop.id)}
+                            onChange={(event) => {
+                              if (event.target.checked) {
+                                setSelectedIds([...selectedIds, workshop.id]);
+                              } else {
+                                setSelectedIds(selectedIds.filter((id) => id !== workshop.id));
+                              }
+                            }}
+                          />
+                          <div>
+                            <p className="font-medium">{workshop.name}</p>
+                            <p className="text-sm text-gray-500">
+                              {formatDate(workshop.availableFrom)} - {formatDate(workshop.availableTo)}
+                            </p>
+                            <p className="text-sm text-gray-500">
+                              Max per day: {workshop.maxRegistrationsPerDay} | Status: {workshop.active ? 'Active' : 'Inactive'}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center space-x-4">
+                          <Button variant="outline" size="sm" onClick={() => openEditModal(workshop)}>Edit</Button>
+                          <button onClick={() => handleDelete(workshop)} className="text-red-500 hover:text-red-700">
+                            <Trash2 className="h-5 w-5" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-600">No workshops found.</p>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default ManageWorkshops;

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -70,8 +70,8 @@ const ManageWorkshops: React.FC = () => {
         setActiveEvent(event);
 
         unsubscribe = subscribeToWorkshopsByEvent(event.id, (liveWorkshops) => {
-            const sorted = [...liveWorkshops].sort((a, b) => a.name.localeCompare(b.name));
-            setWorkshops(sorted);
+          const sorted = [...liveWorkshops].sort((a, b) => a.name.localeCompare(b.name));
+          setWorkshops(sorted);
         });
       } catch (error) {
         console.error('Error loading workshops:', error);
@@ -257,14 +257,14 @@ const ManageWorkshops: React.FC = () => {
               type="date"
               value={editAvailableFrom}
               onChange={(event) => setEditAvailableFrom(event.target.value)}
-              className="w-full rounded border p-2"
+              className="w-full min-w-0 rounded border p-2"
               min={todayKey}
             />
             <input
               type="date"
               value={editAvailableTo}
               onChange={(event) => setEditAvailableTo(event.target.value)}
-              className="w-full rounded border p-2"
+              className="w-full min-w-0 rounded border p-2"
               min={editAvailableFrom || todayKey}
             />
             <label className="block text-sm font-medium text-gray-700">Daily registration limit</label>
@@ -332,46 +332,6 @@ const ManageWorkshops: React.FC = () => {
           <>
             <Card>
               <CardHeader>
-                <CardTitle>Registration Date Mode</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-sm text-gray-600">
-                  Current mode: <span className="font-medium">{isDateSelectionLocked ? 'Locked to current date' : 'Date can be selected manually'}</span>
-                </p>
-                <Button
-                  variant={isDateSelectionLocked ? 'outline' : 'secondary'}
-                  disabled={workshops.length === 0}
-                  onClick={async () => {
-                    if (!activeEvent || workshops.length === 0) {
-                      return;
-                    }
-
-                    try {
-                      await setWorkshopDateLockForEvent(activeEvent.id, !isDateSelectionLocked);
-                      showMessage(
-                        isDateSelectionLocked
-                          ? 'Workshop registration date can now be selected manually.'
-                          : 'Workshop registration date is now locked to the current date.',
-                        'success'
-                      );
-                    } catch (error) {
-                      console.error('Error updating workshop date mode:', error);
-                      showMessage('Failed to update the registration date mode.', 'error');
-                    }
-                  }}
-                >
-                  {isDateSelectionLocked ? 'Allow Manual Date Selection' : 'Lock Registration to Current Date'}
-                </Button>
-                {workshops.length === 0 && (
-                  <p className="text-sm text-gray-500">
-                    Create at least one workshop before changing the registration date mode.
-                  </p>
-                )}
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
                 <CardTitle>Add Workshop</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -389,7 +349,7 @@ const ManageWorkshops: React.FC = () => {
                       type="date"
                       value={availableFrom}
                       onChange={(event) => setAvailableFrom(event.target.value)}
-                      className="w-full rounded border p-2"
+                      className="w-full min-w-0 rounded border p-2"
                       min={todayKey}
                     />
                   </div>
@@ -399,7 +359,7 @@ const ManageWorkshops: React.FC = () => {
                       type="date"
                       value={availableTo}
                       onChange={(event) => setAvailableTo(event.target.value)}
-                      className="w-full rounded border p-2"
+                      className="w-full min-w-0 rounded border p-2"
                       min={availableFrom || todayKey}
                     />
                   </div>
@@ -494,6 +454,46 @@ const ManageWorkshops: React.FC = () => {
                   </div>
                 ) : (
                   <p className="text-sm text-gray-600">No workshops found.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Registration Date Mode</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Current mode: <span className="font-medium">{isDateSelectionLocked ? 'Locked to current date' : 'Date can be selected manually'}</span>
+                </p>
+                <Button
+                  variant={isDateSelectionLocked ? 'outline' : 'success'}
+                  disabled={workshops.length === 0}
+                  onClick={async () => {
+                    if (!activeEvent || workshops.length === 0) {
+                      return;
+                    }
+
+                    try {
+                      await setWorkshopDateLockForEvent(activeEvent.id, !isDateSelectionLocked);
+                      showMessage(
+                        isDateSelectionLocked
+                          ? 'Workshop registration date can now be selected manually.'
+                          : 'Workshop registration date is now locked to the current date.',
+                        'success'
+                      );
+                    } catch (error) {
+                      console.error('Error updating workshop date mode:', error);
+                      showMessage('Failed to update the registration date mode.', 'error');
+                    }
+                  }}
+                >
+                  {isDateSelectionLocked ? 'Allow Manual Date Selection' : 'Lock Registration to Current Date'}
+                </Button>
+                {workshops.length === 0 && (
+                  <p className="text-sm text-gray-500">
+                    Create at least one workshop before changing the registration date mode.
+                  </p>
                 )}
               </CardContent>
             </Card>

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -467,7 +467,7 @@ const ManageWorkshops: React.FC = () => {
                   Current mode: <span className="font-medium">{isDateSelectionLocked ? 'Locked to current date' : 'Date can be selected manually'}</span>
                 </p>
                 <Button
-                  variant={isDateSelectionLocked ? 'outline' : 'success'}
+                  variant={isDateSelectionLocked ? 'outline' : 'primary'}
                   disabled={workshops.length === 0}
                   onClick={async () => {
                     if (!activeEvent || workshops.length === 0) {

--- a/src/pages/ManageWorkshops.tsx
+++ b/src/pages/ManageWorkshops.tsx
@@ -257,14 +257,14 @@ const ManageWorkshops: React.FC = () => {
               type="date"
               value={editAvailableFrom}
               onChange={(event) => setEditAvailableFrom(event.target.value)}
-              className="w-full min-w-0 rounded border p-2"
+              className="block w-full max-w-full min-w-0 box-border rounded border p-2 text-sm"
               min={todayKey}
             />
             <input
               type="date"
               value={editAvailableTo}
               onChange={(event) => setEditAvailableTo(event.target.value)}
-              className="w-full min-w-0 rounded border p-2"
+              className="block w-full max-w-full min-w-0 box-border rounded border p-2 text-sm"
               min={editAvailableFrom || todayKey}
             />
             <label className="block text-sm font-medium text-gray-700">Daily registration limit</label>
@@ -343,23 +343,23 @@ const ManageWorkshops: React.FC = () => {
                   className="w-full rounded border p-2"
                 />
                 <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
+                  <div className="min-w-0 space-y-2">
                     <label className="text-sm font-medium text-gray-700">Available from</label>
                     <input
                       type="date"
                       value={availableFrom}
                       onChange={(event) => setAvailableFrom(event.target.value)}
-                      className="w-full min-w-0 rounded border p-2"
+                      className="block w-full max-w-full min-w-0 box-border rounded border p-2 text-sm"
                       min={todayKey}
                     />
                   </div>
-                  <div className="space-y-2">
+                  <div className="min-w-0 space-y-2">
                     <label className="text-sm font-medium text-gray-700">Available to</label>
                     <input
                       type="date"
                       value={availableTo}
                       onChange={(event) => setAvailableTo(event.target.value)}
-                      className="w-full min-w-0 rounded border p-2"
+                      className="block w-full max-w-full min-w-0 box-border rounded border p-2 text-sm"
                       min={availableFrom || todayKey}
                     />
                   </div>

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -465,17 +465,6 @@ const WorkshopRegistrations: React.FC = () => {
           </Card>
         ) : (
           <>
-            <Card>
-              <CardHeader>
-                <CardTitle>{activeEvent.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-600">
-                  Participants are loaded once for this page session, while workshop availability stays live for the selected date.
-                </p>
-              </CardContent>
-            </Card>
-
             {workshops.length === 0 ? (
               <Card>
                 <CardContent className="p-6">

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -47,7 +47,6 @@ const WorkshopRegistrations: React.FC = () => {
   const [submittingWorkshopId, setSubmittingWorkshopId] = useState<string | null>(null);
   const [deregisteringId, setDeregisteringId] = useState<string | null>(null);
   const [registrationSearchQuery, setRegistrationSearchQuery] = useState('');
-  const setupMessageCount = Number(Boolean(selectedParticipant)) + Number(Boolean(selectedParticipantRegistration));
 
   useEffect(() => {
     let unsubscribeWorkshops: (() => void) | undefined;
@@ -142,6 +141,7 @@ const WorkshopRegistrations: React.FC = () => {
   const selectedParticipantRegistration = registrations.find(
     (registration) => registration.participantId === selectedParticipantId
   ) || null;
+  const setupMessageCount = Number(Boolean(selectedParticipant)) + Number(Boolean(selectedParticipantRegistration));
 
   const filteredParticipants = participants.filter((participant) => {
     const query = participantQuery.trim().toLowerCase();

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -259,7 +259,7 @@ const WorkshopRegistrations: React.FC = () => {
                             onMouseDown={(event) => {
                               event.preventDefault();
                               setSelectedParticipantId(participant.id);
-                              setParticipantQuery(`${participant.name} (${participant.church})`);
+                              setParticipantQuery('');
                               setShowParticipantSuggestions(false);
                             }}
                           >

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -183,10 +183,15 @@ const WorkshopRegistrations: React.FC = () => {
       registration.workshopName.toLowerCase().includes(query)
     );
   });
+  const totalRegistrationsByWorkshop = registrations.reduce<Record<string, number>>((accumulator, registration) => {
+    accumulator[registration.workshopId] = (accumulator[registration.workshopId] || 0) + 1;
+    return accumulator;
+  }, {});
   const workshopGroups = Object.values(
     filteredRegistrations.reduce<Record<string, { workshopName: string; registrations: WorkshopRegistration[] }>>((accumulator, registration) => {
       if (!accumulator[registration.workshopId]) {
         accumulator[registration.workshopId] = {
+          workshopId: registration.workshopId,
           workshopName: registration.workshopName,
           registrations: [],
         };
@@ -197,6 +202,7 @@ const WorkshopRegistrations: React.FC = () => {
     }, {})
   )
     .map((group) => ({
+      workshopId: group.workshopId,
       workshopName: group.workshopName,
       registrations: [...group.registrations].sort((a, b) => a.participantName.localeCompare(b.participantName)),
     }))
@@ -418,7 +424,7 @@ const WorkshopRegistrations: React.FC = () => {
                     <div key={group.workshopName} className="rounded-md border border-gray-200 bg-white">
                       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
                         <h3 className="font-medium text-gray-900">
-                          {group.workshopName} ({group.registrations.length} / {group.registrations.length})
+                          {group.workshopName} ({group.registrations.length} / {totalRegistrationsByWorkshop[group.workshopId] || 0})
                         </h3>
                       </div>
                       <div className="space-y-2 p-3">

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 import AuthGuard from '../components/AuthGuard';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
+import Badge from '../components/ui/Badge';
 import Button from '../components/ui/Button';
 import LoadingSpinner from '../components/LoadingSpinner';
 import Tabs from '../components/ui/Tabs';
@@ -217,7 +218,7 @@ const WorkshopRegistrations: React.FC = () => {
             <CardHeader>
               <CardTitle>Registration Setup</CardTitle>
             </CardHeader>
-            <CardContent className={`space-y-4 ${setupMessageCount > 0 ? 'pb-4' : 'pb-2'}`}>
+            <CardContent className={`space-y-4 ${setupMessageCount > 0 ? 'pb-4' : 'pb-4'}`}>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-gray-700">Workshop date</label>
@@ -402,9 +403,10 @@ const WorkshopRegistrations: React.FC = () => {
                     >
                       <div>
                         <p className="font-medium">{registration.participantName}</p>
-                        <p className="text-sm text-gray-500">
-                          {registration.participantChurch} | {registration.workshopName}
-                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
+                          <span>{registration.participantChurch}</span>
+                          <Badge variant="primary">{registration.workshopName}</Badge>
+                        </div>
                       </div>
                       <Button
                         variant="danger"

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -21,6 +21,7 @@ import { Event, Participant, Workshop, WorkshopDailyCount, WorkshopRegistration 
 import {
   CURRENT_DATE_REFERENCE,
   formatDate,
+  formatDateKey,
   getUpcomingWorkshopDateKeys,
   isDateWithinRange,
   parseDateKey,
@@ -99,8 +100,16 @@ const WorkshopRegistrations: React.FC = () => {
   };
 
   const dateOptions = getUpcomingWorkshopDateKeys(workshops, CURRENT_DATE_REFERENCE);
+  const currentDateKey = formatDateKey(CURRENT_DATE_REFERENCE);
+  const isDateSelectionLocked = workshops.length > 0 && workshops.every((workshop) => workshop.lockRegistrationDateToToday);
+  const visibleDateOptions = isDateSelectionLocked ? [currentDateKey] : dateOptions;
 
   useEffect(() => {
+    if (isDateSelectionLocked) {
+      setSelectedDateKey(currentDateKey);
+      return;
+    }
+
     if (!dateOptions.length) {
       setSelectedDateKey('');
       return;
@@ -109,7 +118,7 @@ const WorkshopRegistrations: React.FC = () => {
     if (!selectedDateKey || !dateOptions.includes(selectedDateKey)) {
       setSelectedDateKey(dateOptions[0]);
     }
-  }, [dateOptions, selectedDateKey]);
+  }, [currentDateKey, dateOptions, isDateSelectionLocked, selectedDateKey]);
 
   useEffect(() => {
     if (!activeEvent || !selectedDateKey) {
@@ -216,12 +225,12 @@ const WorkshopRegistrations: React.FC = () => {
                     value={selectedDateKey}
                     onChange={(event) => setSelectedDateKey(event.target.value)}
                     className="w-full rounded border border-gray-300 p-2"
-                    disabled={!dateOptions.length}
+                    disabled={isDateSelectionLocked || visibleDateOptions.length === 0}
                   >
-                    {dateOptions.length === 0 ? (
+                    {visibleDateOptions.length === 0 ? (
                       <option value="">No current or future workshop dates</option>
                     ) : (
-                      dateOptions.map((dateKey) => (
+                      visibleDateOptions.map((dateKey) => (
                         <option key={dateKey} value={dateKey}>
                           {formatDate(parseDateKey(dateKey))}
                         </option>

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -47,6 +47,7 @@ const WorkshopRegistrations: React.FC = () => {
   const [submittingWorkshopId, setSubmittingWorkshopId] = useState<string | null>(null);
   const [deregisteringId, setDeregisteringId] = useState<string | null>(null);
   const [registrationSearchQuery, setRegistrationSearchQuery] = useState('');
+  const setupMessageCount = Number(Boolean(selectedParticipant)) + Number(Boolean(selectedParticipantRegistration));
 
   useEffect(() => {
     let unsubscribeWorkshops: (() => void) | undefined;
@@ -207,7 +208,7 @@ const WorkshopRegistrations: React.FC = () => {
             <CardHeader>
               <CardTitle>Registration Setup</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4 pb-24">
+            <CardContent className={`space-y-4 ${setupMessageCount > 0 ? 'pb-4' : 'pb-2'}`}>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-gray-700">Workshop date</label>

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -183,6 +183,24 @@ const WorkshopRegistrations: React.FC = () => {
       registration.workshopName.toLowerCase().includes(query)
     );
   });
+  const workshopGroups = Object.values(
+    filteredRegistrations.reduce<Record<string, { workshopName: string; registrations: WorkshopRegistration[] }>>((accumulator, registration) => {
+      if (!accumulator[registration.workshopId]) {
+        accumulator[registration.workshopId] = {
+          workshopName: registration.workshopName,
+          registrations: [],
+        };
+      }
+
+      accumulator[registration.workshopId].registrations.push(registration);
+      return accumulator;
+    }, {})
+  )
+    .map((group) => ({
+      workshopName: group.workshopName,
+      registrations: [...group.registrations].sort((a, b) => a.participantName.localeCompare(b.participantName)),
+    }))
+    .sort((a, b) => a.workshopName.localeCompare(b.workshopName));
 
   const refreshSelectedDate = async () => {
     if (!activeEvent || !selectedDateKey) {
@@ -394,46 +412,55 @@ const WorkshopRegistrations: React.FC = () => {
               </Button>
             </CardHeader>
             <CardContent>
-              {filteredRegistrations.length > 0 ? (
-                <div className="space-y-2">
-                  {filteredRegistrations.map((registration) => (
-                    <div
-                      key={registration.id}
-                      className="flex items-center justify-between rounded-md border border-gray-200 bg-white p-3 hover:bg-gray-50"
-                    >
-                      <div>
-                        <p className="font-medium">{registration.participantName}</p>
-                        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
-                          <span>{registration.participantChurch}</span>
-                          <Badge variant="primary">{registration.workshopName}</Badge>
+              {workshopGroups.length > 0 ? (
+                <div className="space-y-4">
+                  {workshopGroups.map((group) => (
+                    <div key={group.workshopName} className="rounded-md border border-gray-200 bg-white">
+                      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-medium text-gray-900">{group.workshopName}</h3>
+                          <Badge variant="primary">{group.registrations.length}</Badge>
                         </div>
                       </div>
-                      <Button
-                        variant="danger"
-                        size="sm"
-                        isLoading={deregisteringId === registration.id}
-                        onClick={async () => {
-                          if (!activeEvent) {
-                            return;
-                          }
+                      <div className="space-y-2 p-3">
+                        {group.registrations.map((registration) => (
+                          <div
+                            key={registration.id}
+                            className="flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 p-3 hover:bg-gray-100"
+                          >
+                            <div>
+                              <p className="font-medium">{registration.participantName}</p>
+                              <p className="text-sm text-gray-500">{registration.participantChurch}</p>
+                            </div>
+                            <Button
+                              variant="danger"
+                              size="sm"
+                              isLoading={deregisteringId === registration.id}
+                              onClick={async () => {
+                                if (!activeEvent) {
+                                  return;
+                                }
 
-                          setDeregisteringId(registration.id);
-                          try {
-                            await deregisterParticipantFromWorkshop({
-                              eventId: activeEvent.id,
-                              registration,
-                            });
-                            showMessage(`Removed ${registration.participantName} from ${registration.workshopName}.`, 'success');
-                          } catch (error) {
-                            console.error('Error deregistering participant:', error);
-                            showMessage(error instanceof Error ? error.message : 'Failed to deregister participant.', 'error');
-                          } finally {
-                            setDeregisteringId(null);
-                          }
-                        }}
-                      >
-                        De-register
-                      </Button>
+                                setDeregisteringId(registration.id);
+                                try {
+                                  await deregisterParticipantFromWorkshop({
+                                    eventId: activeEvent.id,
+                                    registration,
+                                  });
+                                  showMessage(`Removed ${registration.participantName} from ${registration.workshopName}.`, 'success');
+                                } catch (error) {
+                                  console.error('Error deregistering participant:', error);
+                                  showMessage(error instanceof Error ? error.message : 'Failed to deregister participant.', 'error');
+                                } finally {
+                                  setDeregisteringId(null);
+                                }
+                              }}
+                            >
+                              De-register
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -46,6 +46,7 @@ const WorkshopRegistrations: React.FC = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [submittingWorkshopId, setSubmittingWorkshopId] = useState<string | null>(null);
   const [deregisteringId, setDeregisteringId] = useState<string | null>(null);
+  const [registrationSearchQuery, setRegistrationSearchQuery] = useState('');
 
   useEffect(() => {
     let unsubscribeWorkshops: (() => void) | undefined;
@@ -159,6 +160,18 @@ const WorkshopRegistrations: React.FC = () => {
   }, {});
 
   const selectedDate = selectedDateKey ? parseDateKey(selectedDateKey) : null;
+  const filteredRegistrations = registrations.filter((registration) => {
+    const query = registrationSearchQuery.trim().toLowerCase();
+    if (!query) {
+      return true;
+    }
+
+    return (
+      registration.participantName.toLowerCase().includes(query) ||
+      registration.participantChurch.toLowerCase().includes(query) ||
+      registration.workshopName.toLowerCase().includes(query)
+    );
+  });
 
   const refreshSelectedDate = async () => {
     if (!activeEvent || !selectedDateKey) {
@@ -190,11 +203,11 @@ const WorkshopRegistrations: React.FC = () => {
       label: 'Register',
       content: (
         <div className="space-y-6">
-          <Card>
+          <Card className="overflow-visible">
             <CardHeader>
               <CardTitle>Registration Setup</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-4 pb-24">
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-gray-700">Workshop date</label>
@@ -273,7 +286,7 @@ const WorkshopRegistrations: React.FC = () => {
             </CardContent>
           </Card>
 
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {workshops.map((workshop) => {
               const availableOnSelectedDate = selectedDate ? isDateWithinRange(selectedDate, workshop.availableFrom, workshop.availableTo) : false;
               const count = countMap[workshop.id]?.count || 0;
@@ -296,16 +309,16 @@ const WorkshopRegistrations: React.FC = () => {
               );
 
               return (
-                <Card key={workshop.id} className="h-full">
-                  <CardHeader>
-                    <CardTitle>{workshop.name}</CardTitle>
+                <Card key={workshop.id}>
+                  <CardHeader className="py-3">
+                    <CardTitle className="text-base">
+                      {workshop.name} ({count} / {workshop.maxRegistrationsPerDay})
+                    </CardTitle>
                   </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-1 text-sm text-gray-600">
-                      <p>{formatDate(workshop.availableFrom)} - {formatDate(workshop.availableTo)}</p>
-                      <p>Capacity for selected date: {count} / {workshop.maxRegistrationsPerDay}</p>
-                      <p>Status: {disabledReason || 'Available'}</p>
-                    </div>
+                  <CardContent className="space-y-3">
+                    {disabledReason && (
+                      <p className="text-sm text-gray-500">{disabledReason}</p>
+                    )}
                     <Button
                       fullWidth
                       disabled={!canRegister}
@@ -352,18 +365,27 @@ const WorkshopRegistrations: React.FC = () => {
         <div className="space-y-6">
           <Card>
             <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <CardTitle>
-                {selectedDate ? `Registrations for ${formatDate(selectedDate)}` : 'Registrations'}
-              </CardTitle>
+              <div className="space-y-3">
+                <CardTitle>
+                  {selectedDate ? `Registrations for ${formatDate(selectedDate)}` : 'Registrations'}
+                </CardTitle>
+                <input
+                  type="text"
+                  value={registrationSearchQuery}
+                  onChange={(event) => setRegistrationSearchQuery(event.target.value)}
+                  placeholder="Search participant, church, or workshop"
+                  className="w-full rounded border border-gray-300 px-3 py-2 text-sm md:w-80"
+                />
+              </div>
               <Button variant="outline" onClick={refreshSelectedDate} isLoading={refreshing}>
                 <RefreshCw className="mr-2 h-4 w-4" />
                 Refresh
               </Button>
             </CardHeader>
             <CardContent>
-              {registrations.length > 0 ? (
+              {filteredRegistrations.length > 0 ? (
                 <div className="space-y-2">
-                  {registrations.map((registration) => (
+                  {filteredRegistrations.map((registration) => (
                     <div
                       key={registration.id}
                       className="flex items-center justify-between rounded-md border border-gray-200 bg-white p-3 hover:bg-gray-50"
@@ -403,6 +425,8 @@ const WorkshopRegistrations: React.FC = () => {
                     </div>
                   ))}
                 </div>
+              ) : registrations.length > 0 ? (
+                <p className="text-sm text-gray-600">No registrations match the current search.</p>
               ) : (
                 <p className="text-sm text-gray-600">No registrations found for the selected date.</p>
               )}

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -417,10 +417,9 @@ const WorkshopRegistrations: React.FC = () => {
                   {workshopGroups.map((group) => (
                     <div key={group.workshopName} className="rounded-md border border-gray-200 bg-white">
                       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <h3 className="font-medium text-gray-900">{group.workshopName}</h3>
-                          <Badge variant="primary">{group.registrations.length}</Badge>
-                        </div>
+                        <h3 className="font-medium text-gray-900">
+                          {group.workshopName} ({group.registrations.length} / {group.registrations.length})
+                        </h3>
                       </div>
                       <div className="space-y-2 p-3">
                         {group.registrations.map((registration) => (

--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -1,0 +1,470 @@
+import React, { useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useParams } from 'react-router-dom';
+import AuthGuard from '../components/AuthGuard';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import LoadingSpinner from '../components/LoadingSpinner';
+import Tabs from '../components/ui/Tabs';
+import {
+  deregisterParticipantFromWorkshop,
+  getEventById,
+  getParticipantsByEvent,
+  getWorkshopDailyCountsByDate,
+  getWorkshopRegistrationsByDate,
+  registerParticipantForWorkshop,
+  subscribeToWorkshopDailyCountsByDate,
+  subscribeToWorkshopRegistrationsByDate,
+  subscribeToWorkshopsByEvent,
+} from '../utils/firebase';
+import { Event, Participant, Workshop, WorkshopDailyCount, WorkshopRegistration } from '../types';
+import {
+  CURRENT_DATE_REFERENCE,
+  formatDate,
+  getUpcomingWorkshopDateKeys,
+  isDateWithinRange,
+  parseDateKey,
+} from '../utils/helpers';
+import { useUser } from '../context/UserContext';
+
+const WorkshopRegistrations: React.FC = () => {
+  const { eventId } = useParams<{ eventId: string }>();
+  const { user } = useUser();
+  const [activeEvent, setActiveEvent] = useState<Event | null>(null);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [workshops, setWorkshops] = useState<Workshop[]>([]);
+  const [registrations, setRegistrations] = useState<WorkshopRegistration[]>([]);
+  const [counts, setCounts] = useState<WorkshopDailyCount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedDateKey, setSelectedDateKey] = useState('');
+  const [selectedParticipantId, setSelectedParticipantId] = useState('');
+  const [participantQuery, setParticipantQuery] = useState('');
+  const [showParticipantSuggestions, setShowParticipantSuggestions] = useState(false);
+  const [activeTabId, setActiveTabId] = useState('register');
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+  const [refreshing, setRefreshing] = useState(false);
+  const [submittingWorkshopId, setSubmittingWorkshopId] = useState<string | null>(null);
+  const [deregisteringId, setDeregisteringId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unsubscribeWorkshops: (() => void) | undefined;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        if (!eventId) {
+          setActiveEvent(null);
+          return;
+        }
+
+        const event = await getEventById(eventId);
+        if (!event.active) {
+          setActiveEvent(null);
+          return;
+        }
+
+        setActiveEvent(event);
+
+        const participantData = await getParticipantsByEvent(event.id);
+        participantData.sort((a, b) => a.name.localeCompare(b.name));
+        setParticipants(participantData);
+
+        unsubscribeWorkshops = subscribeToWorkshopsByEvent(event.id, (liveWorkshops) => {
+          const sorted = [...liveWorkshops].sort((a, b) => a.name.localeCompare(b.name));
+          setWorkshops(sorted);
+        });
+      } catch (error) {
+        console.error('Error loading workshop registration page:', error);
+        showMessage('Failed to load workshop registration data.', 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      if (unsubscribeWorkshops) {
+        unsubscribeWorkshops();
+      }
+    };
+  }, [eventId]);
+
+  const showMessage = (text: string, type: 'success' | 'error' = 'success') => {
+    setMessage(text);
+    setMessageType(type);
+    setTimeout(() => setMessage(null), 3500);
+  };
+
+  const dateOptions = getUpcomingWorkshopDateKeys(workshops, CURRENT_DATE_REFERENCE);
+
+  useEffect(() => {
+    if (!dateOptions.length) {
+      setSelectedDateKey('');
+      return;
+    }
+
+    if (!selectedDateKey || !dateOptions.includes(selectedDateKey)) {
+      setSelectedDateKey(dateOptions[0]);
+    }
+  }, [dateOptions, selectedDateKey]);
+
+  useEffect(() => {
+    if (!activeEvent || !selectedDateKey) {
+      setRegistrations([]);
+      setCounts([]);
+      return;
+    }
+
+    const unsubscribeRegistrations = subscribeToWorkshopRegistrationsByDate(
+      activeEvent.id,
+      selectedDateKey,
+      (liveRegistrations) => {
+        const sorted = [...liveRegistrations].sort((a, b) => a.participantName.localeCompare(b.participantName));
+        setRegistrations(sorted);
+      }
+    );
+
+    const unsubscribeCounts = subscribeToWorkshopDailyCountsByDate(activeEvent.id, selectedDateKey, (liveCounts) => {
+      setCounts(liveCounts);
+    });
+
+    return () => {
+      unsubscribeRegistrations();
+      unsubscribeCounts();
+    };
+  }, [activeEvent, selectedDateKey]);
+
+  const selectedParticipant = participants.find((participant) => participant.id === selectedParticipantId) || null;
+  const selectedParticipantRegistration = registrations.find(
+    (registration) => registration.participantId === selectedParticipantId
+  ) || null;
+
+  const filteredParticipants = participants.filter((participant) => {
+    const query = participantQuery.trim().toLowerCase();
+    if (!query) {
+      return true;
+    }
+
+    return (
+      participant.name.toLowerCase().includes(query) ||
+      participant.church.toLowerCase().includes(query)
+    );
+  });
+
+  const countMap = counts.reduce<Record<string, WorkshopDailyCount>>((accumulator, count) => {
+    accumulator[count.workshopId] = count;
+    return accumulator;
+  }, {});
+
+  const selectedDate = selectedDateKey ? parseDateKey(selectedDateKey) : null;
+
+  const refreshSelectedDate = async () => {
+    if (!activeEvent || !selectedDateKey) {
+      return;
+    }
+
+    setRefreshing(true);
+    try {
+      const [registrationData, countData] = await Promise.all([
+        getWorkshopRegistrationsByDate(activeEvent.id, selectedDateKey),
+        getWorkshopDailyCountsByDate(activeEvent.id, selectedDateKey),
+      ]);
+
+      registrationData.sort((a, b) => a.participantName.localeCompare(b.participantName));
+      setRegistrations(registrationData);
+      setCounts(countData);
+      showMessage('Workshop registrations refreshed.', 'success');
+    } catch (error) {
+      console.error('Error refreshing workshop registrations:', error);
+      showMessage('Failed to refresh workshop registrations.', 'error');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const tabs = [
+    {
+      id: 'register',
+      label: 'Register',
+      content: (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Registration Setup</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Workshop date</label>
+                  <select
+                    value={selectedDateKey}
+                    onChange={(event) => setSelectedDateKey(event.target.value)}
+                    className="w-full rounded border border-gray-300 p-2"
+                    disabled={!dateOptions.length}
+                  >
+                    {dateOptions.length === 0 ? (
+                      <option value="">No current or future workshop dates</option>
+                    ) : (
+                      dateOptions.map((dateKey) => (
+                        <option key={dateKey} value={dateKey}>
+                          {formatDate(parseDateKey(dateKey))}
+                        </option>
+                      ))
+                    )}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Participant</label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      value={participantQuery}
+                      onChange={(event) => {
+                        setParticipantQuery(event.target.value);
+                        setShowParticipantSuggestions(true);
+                        if (!event.target.value.trim()) {
+                          setSelectedParticipantId('');
+                        }
+                      }}
+                      onFocus={() => setShowParticipantSuggestions(true)}
+                      onBlur={() => {
+                        setTimeout(() => setShowParticipantSuggestions(false), 150);
+                      }}
+                      placeholder="Search participant by name or church"
+                      className="w-full rounded border border-gray-300 p-2"
+                    />
+                    {showParticipantSuggestions && filteredParticipants.length > 0 && (
+                      <div className="absolute z-10 mt-1 max-h-64 w-full overflow-y-auto rounded border border-gray-200 bg-white shadow-lg">
+                        {filteredParticipants.slice(0, 20).map((participant) => (
+                          <button
+                            key={participant.id}
+                            type="button"
+                            className="block w-full px-3 py-2 text-left text-sm hover:bg-gray-50"
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              setSelectedParticipantId(participant.id);
+                              setParticipantQuery(`${participant.name} (${participant.church})`);
+                              setShowParticipantSuggestions(false);
+                            }}
+                          >
+                            <span className="font-medium">{participant.name}</span>
+                            <span className="ml-2 text-gray-500">{participant.church}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {selectedParticipant && (
+                <div className="rounded-md border border-teal-200 bg-teal-50 p-3 text-sm text-teal-900">
+                  Selected participant: <span className="font-medium">{selectedParticipant.name}</span> from {selectedParticipant.church}
+                </div>
+              )}
+
+              {selectedParticipantRegistration && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                  This participant is already registered for <span className="font-medium">{selectedParticipantRegistration.workshopName}</span> on {selectedDate ? formatDate(selectedDate) : selectedDateKey}.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {workshops.map((workshop) => {
+              const availableOnSelectedDate = selectedDate ? isDateWithinRange(selectedDate, workshop.availableFrom, workshop.availableTo) : false;
+              const count = countMap[workshop.id]?.count || 0;
+              const isFull = count >= workshop.maxRegistrationsPerDay;
+              const disabledReason = !workshop.active
+                ? 'Inactive'
+                : !availableOnSelectedDate
+                  ? 'Unavailable on this date'
+                  : isFull
+                    ? 'Full'
+                    : '';
+              const canRegister = Boolean(
+                activeEvent &&
+                selectedParticipant &&
+                selectedDateKey &&
+                workshop.active &&
+                availableOnSelectedDate &&
+                !isFull &&
+                !selectedParticipantRegistration
+              );
+
+              return (
+                <Card key={workshop.id} className="h-full">
+                  <CardHeader>
+                    <CardTitle>{workshop.name}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="space-y-1 text-sm text-gray-600">
+                      <p>{formatDate(workshop.availableFrom)} - {formatDate(workshop.availableTo)}</p>
+                      <p>Capacity for selected date: {count} / {workshop.maxRegistrationsPerDay}</p>
+                      <p>Status: {disabledReason || 'Available'}</p>
+                    </div>
+                    <Button
+                      fullWidth
+                      disabled={!canRegister}
+                      isLoading={submittingWorkshopId === workshop.id}
+                      onClick={async () => {
+                        if (!activeEvent || !selectedParticipant || !user || !selectedDateKey) {
+                          return;
+                        }
+
+                        setSubmittingWorkshopId(workshop.id);
+                        try {
+                          await registerParticipantForWorkshop({
+                            eventId: activeEvent.id,
+                            workshopId: workshop.id,
+                            participant: selectedParticipant,
+                            registeredBy: user.id,
+                            dateKey: selectedDateKey,
+                          });
+                          setSelectedParticipantId('');
+                          setParticipantQuery('');
+                          showMessage(`Registered ${selectedParticipant.name} for ${workshop.name}.`, 'success');
+                        } catch (error) {
+                          console.error('Error registering participant for workshop:', error);
+                          showMessage(error instanceof Error ? error.message : 'Failed to register participant.', 'error');
+                        } finally {
+                          setSubmittingWorkshopId(null);
+                        }
+                      }}
+                    >
+                      Register
+                    </Button>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'registrations',
+      label: 'Current Registrations',
+      content: (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <CardTitle>
+                {selectedDate ? `Registrations for ${formatDate(selectedDate)}` : 'Registrations'}
+              </CardTitle>
+              <Button variant="outline" onClick={refreshSelectedDate} isLoading={refreshing}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Refresh
+              </Button>
+            </CardHeader>
+            <CardContent>
+              {registrations.length > 0 ? (
+                <div className="space-y-2">
+                  {registrations.map((registration) => (
+                    <div
+                      key={registration.id}
+                      className="flex items-center justify-between rounded-md border border-gray-200 bg-white p-3 hover:bg-gray-50"
+                    >
+                      <div>
+                        <p className="font-medium">{registration.participantName}</p>
+                        <p className="text-sm text-gray-500">
+                          {registration.participantChurch} | {registration.workshopName}
+                        </p>
+                      </div>
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        isLoading={deregisteringId === registration.id}
+                        onClick={async () => {
+                          if (!activeEvent) {
+                            return;
+                          }
+
+                          setDeregisteringId(registration.id);
+                          try {
+                            await deregisterParticipantFromWorkshop({
+                              eventId: activeEvent.id,
+                              registration,
+                            });
+                            showMessage(`Removed ${registration.participantName} from ${registration.workshopName}.`, 'success');
+                          } catch (error) {
+                            console.error('Error deregistering participant:', error);
+                            showMessage(error instanceof Error ? error.message : 'Failed to deregister participant.', 'error');
+                          } finally {
+                            setDeregisteringId(null);
+                          }
+                        }}
+                      >
+                        De-register
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-600">No registrations found for the selected date.</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      ),
+    },
+  ];
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <AuthGuard>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-gray-900">Workshop Registrations</h1>
+
+        {message && (
+          <div className={`fixed top-6 left-1/2 z-50 -translate-x-1/2 rounded-md border px-4 py-2 text-sm shadow-lg transition-opacity duration-300 ${
+            messageType === 'success'
+              ? 'border-green-300 bg-green-50 text-green-800'
+              : 'border-red-300 bg-red-50 text-red-800'
+          }`}>
+            {message}
+          </div>
+        )}
+
+        {!activeEvent ? (
+          <Card>
+            <CardContent className="p-6">
+              <p className="text-sm text-gray-600">No active event is available right now.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>{activeEvent.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-gray-600">
+                  Participants are loaded once for this page session, while workshop availability stays live for the selected date.
+                </p>
+              </CardContent>
+            </Card>
+
+            {workshops.length === 0 ? (
+              <Card>
+                <CardContent className="p-6">
+                  <p className="text-sm text-gray-600">No workshops have been created for the active event yet.</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <Tabs tabs={tabs} activeTabId={activeTabId} onTabChange={setActiveTabId} />
+            )}
+          </>
+        )}
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default WorkshopRegistrations;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface Workshop {
   availableFrom: Date;
   availableTo: Date;
   maxRegistrationsPerDay: number;
+  lockRegistrationDateToToday: boolean;
   active: boolean;
   createdAt: Date;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,37 @@ export interface Activity {
   createdAt: Date;
 }
 
+export interface Workshop {
+  id: string;
+  name: string;
+  availableFrom: Date;
+  availableTo: Date;
+  maxRegistrationsPerDay: number;
+  active: boolean;
+  createdAt: Date;
+}
+
+export interface WorkshopRegistration {
+  id: string;
+  workshopId: string;
+  workshopName: string;
+  participantId: string;
+  participantName: string;
+  participantChurch: string;
+  dateKey: string;
+  registeredBy: string;
+  registeredAt: Date;
+}
+
+export interface WorkshopDailyCount {
+  id: string;
+  workshopId: string;
+  workshopName: string;
+  dateKey: string;
+  count: number;
+  maxRegistrations: number;
+}
+
 export interface ActivityLog {
   id: string;
   participantId: string;

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -953,6 +953,7 @@ export async function registerParticipantForWorkshop({
   dateKey: string;
 }) {
   const workshopRef = doc(db, 'events', eventId, 'workshops', workshopId);
+  const participantRef = doc(db, 'events', eventId, 'participants', participant.id);
   const registrationRef = doc(
     db,
     'events',
@@ -963,9 +964,14 @@ export async function registerParticipantForWorkshop({
 
   await runTransaction(db, async (transaction) => {
     const workshopSnap = await transaction.get(workshopRef);
+    const participantSnap = await transaction.get(participantRef);
 
     if (!workshopSnap.exists()) {
       throw new Error('Workshop not found.');
+    }
+
+    if (!participantSnap.exists()) {
+      throw new Error('Participant no longer exists for this event.');
     }
 
     const workshopData = workshopSnap.data() as Omit<Workshop, 'availableFrom' | 'availableTo' | 'createdAt'> & {
@@ -1055,15 +1061,26 @@ export async function deregisterParticipantFromWorkshop({
       throw new Error('Registration no longer exists.');
     }
 
-    const countSnap = await transaction.get(countRef);
+    const liveRegistration = registrationSnap.data() as Omit<WorkshopRegistration, 'registeredAt'> & {
+      registeredAt: Timestamp;
+    };
+    const liveCountRef = doc(
+      db,
+      'events',
+      eventId,
+      'workshopDailyCounts',
+      buildWorkshopDailyCountId(liveRegistration.workshopId, liveRegistration.dateKey)
+    );
+
+    const countSnap = await transaction.get(liveCountRef);
     const currentCount = countSnap.exists() ? (countSnap.data().count as number) : 0;
 
     transaction.delete(registrationRef);
 
     if (currentCount <= 1) {
-      transaction.delete(countRef);
+      transaction.delete(liveCountRef);
     } else {
-      transaction.update(countRef, { count: currentCount - 1 });
+      transaction.update(liveCountRef, { count: currentCount - 1 });
     }
   });
 }

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -14,9 +14,12 @@ import {
   Timestamp,
   writeBatch,
   addDoc,
-  serverTimestamp 
+  serverTimestamp,
+  onSnapshot,
+  runTransaction
 } from 'firebase/firestore';
-import { User, Participant, Activity, ActivityLog, Event } from '../types';
+import { User, Participant, Activity, ActivityLog, Event, Workshop, WorkshopRegistration, WorkshopDailyCount } from '../types';
+import { formatDateKey, isDateWithinRange } from './helpers';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -696,6 +699,372 @@ export async function deleteActivity(eventId: string, activityId: string) {
 export async function updateActivity(activityId: string, updates: Partial<Activity>) {
   const ref = doc(db, 'activities', activityId);
   await updateDoc(ref, updates);
+}
+
+// Workshop related functions
+
+export async function createWorkshop(eventId: string, workshop: Omit<Workshop, 'id' | 'createdAt'>) {
+  const workshopsRef = collection(db, 'events', eventId, 'workshops');
+  const workshopRef = doc(workshopsRef);
+  const newWorkshop: Workshop = {
+    ...workshop,
+    id: workshopRef.id,
+    createdAt: new Date(),
+  };
+
+  await setDoc(workshopRef, newWorkshop);
+  return newWorkshop;
+}
+
+export async function updateWorkshop(eventId: string, workshopId: string, updates: Partial<Workshop>) {
+  const workshopRef = doc(db, 'events', eventId, 'workshops', workshopId);
+  await updateDoc(workshopRef, updates);
+}
+
+export async function getWorkshopsByEvent(eventId: string): Promise<Workshop[]> {
+  const snapshot = await getDocs(collection(db, 'events', eventId, 'workshops'));
+  const workshops: Workshop[] = [];
+
+  snapshot.forEach((docSnap) => {
+    const data = docSnap.data() as Omit<Workshop, 'availableFrom' | 'availableTo' | 'createdAt'> & {
+      availableFrom: Timestamp;
+      availableTo: Timestamp;
+      createdAt: Timestamp;
+    };
+
+    workshops.push({
+      id: docSnap.id,
+      ...data,
+      availableFrom: data.availableFrom.toDate(),
+      availableTo: data.availableTo.toDate(),
+      createdAt: data.createdAt.toDate(),
+    });
+  });
+
+  return workshops;
+}
+
+export function subscribeToWorkshopsByEvent(
+  eventId: string,
+  callback: (workshops: Workshop[]) => void
+) {
+  return onSnapshot(collection(db, 'events', eventId, 'workshops'), (snapshot) => {
+    const workshops: Workshop[] = snapshot.docs.map((docSnap) => {
+      const data = docSnap.data() as Omit<Workshop, 'availableFrom' | 'availableTo' | 'createdAt'> & {
+        availableFrom: Timestamp;
+        availableTo: Timestamp;
+        createdAt: Timestamp;
+      };
+
+      return {
+        id: docSnap.id,
+        ...data,
+        availableFrom: data.availableFrom.toDate(),
+        availableTo: data.availableTo.toDate(),
+        createdAt: data.createdAt.toDate(),
+      };
+    });
+
+    callback(workshops);
+  });
+}
+
+export async function deleteWorkshop(eventId: string, workshopId: string) {
+  const countsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopDailyCounts'));
+  const registrationsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopRegistrations'));
+
+  const batch = writeBatch(db);
+
+  countsSnapshot.docs.forEach((docSnap) => {
+    if (docSnap.data().workshopId === workshopId) {
+      batch.delete(docSnap.ref);
+    }
+  });
+
+  registrationsSnapshot.docs.forEach((docSnap) => {
+    if (docSnap.data().workshopId === workshopId) {
+      batch.delete(docSnap.ref);
+    }
+  });
+
+  batch.delete(doc(db, 'events', eventId, 'workshops', workshopId));
+  await batch.commit();
+}
+
+export function subscribeToWorkshopRegistrationsByDate(
+  eventId: string,
+  dateKey: string,
+  callback: (registrations: WorkshopRegistration[]) => void
+) {
+  const registrationsQuery = query(
+    collection(db, 'events', eventId, 'workshopRegistrations'),
+    where('dateKey', '==', dateKey)
+  );
+
+  return onSnapshot(registrationsQuery, (snapshot) => {
+    const registrations: WorkshopRegistration[] = snapshot.docs.map((docSnap) => {
+      const data = docSnap.data() as Omit<WorkshopRegistration, 'registeredAt'> & {
+        registeredAt: Timestamp;
+      };
+
+      return {
+        id: docSnap.id,
+        ...data,
+        registeredAt: data.registeredAt.toDate(),
+      };
+    });
+
+    callback(registrations);
+  });
+}
+
+export function subscribeToWorkshopDailyCountsByDate(
+  eventId: string,
+  dateKey: string,
+  callback: (counts: WorkshopDailyCount[]) => void
+) {
+  const countsQuery = query(
+    collection(db, 'events', eventId, 'workshopDailyCounts'),
+    where('dateKey', '==', dateKey)
+  );
+
+  return onSnapshot(countsQuery, (snapshot) => {
+    const counts: WorkshopDailyCount[] = snapshot.docs.map((docSnap) => ({
+      id: docSnap.id,
+      ...(docSnap.data() as Omit<WorkshopDailyCount, 'id'>),
+    }));
+
+    callback(counts);
+  });
+}
+
+function buildWorkshopRegistrationId(dateKey: string, participantId: string) {
+  return `${dateKey}__${participantId}`;
+}
+
+function buildWorkshopDailyCountId(workshopId: string, dateKey: string) {
+  return `${workshopId}__${dateKey}`;
+}
+
+export async function registerParticipantForWorkshop({
+  eventId,
+  workshopId,
+  participant,
+  registeredBy,
+  dateKey,
+}: {
+  eventId: string;
+  workshopId: string;
+  participant: Participant;
+  registeredBy: string;
+  dateKey: string;
+}) {
+  const workshopRef = doc(db, 'events', eventId, 'workshops', workshopId);
+  const registrationRef = doc(
+    db,
+    'events',
+    eventId,
+    'workshopRegistrations',
+    buildWorkshopRegistrationId(dateKey, participant.id)
+  );
+
+  await runTransaction(db, async (transaction) => {
+    const workshopSnap = await transaction.get(workshopRef);
+
+    if (!workshopSnap.exists()) {
+      throw new Error('Workshop not found.');
+    }
+
+    const workshopData = workshopSnap.data() as Omit<Workshop, 'availableFrom' | 'availableTo' | 'createdAt'> & {
+      availableFrom: Timestamp;
+      availableTo: Timestamp;
+      createdAt: Timestamp;
+    };
+
+    const workshop: Workshop = {
+      id: workshopSnap.id,
+      ...workshopData,
+      availableFrom: workshopData.availableFrom.toDate(),
+      availableTo: workshopData.availableTo.toDate(),
+      createdAt: workshopData.createdAt.toDate(),
+    };
+
+    const selectedDate = new Date(`${dateKey}T00:00:00`);
+
+    if (!workshop.active || !isDateWithinRange(selectedDate, workshop.availableFrom, workshop.availableTo)) {
+      throw new Error('This workshop is not available on the selected date.');
+    }
+
+    const existingRegistrationSnap = await transaction.get(registrationRef);
+    if (existingRegistrationSnap.exists()) {
+      const existing = existingRegistrationSnap.data() as WorkshopRegistration;
+      if (existing.workshopId === workshopId) {
+        throw new Error('Participant is already registered for this workshop on that date.');
+      }
+      throw new Error(`Participant is already registered for ${existing.workshopName} on that date.`);
+    }
+
+    const countRef = doc(
+      db,
+      'events',
+      eventId,
+      'workshopDailyCounts',
+      buildWorkshopDailyCountId(workshopId, dateKey)
+    );
+    const countSnap = await transaction.get(countRef);
+    const currentCount = countSnap.exists() ? (countSnap.data().count as number) : 0;
+
+    if (currentCount >= workshop.maxRegistrationsPerDay) {
+      throw new Error('This workshop just reached its maximum registrations.');
+    }
+
+    transaction.set(registrationRef, {
+      workshopId: workshop.id,
+      workshopName: workshop.name,
+      participantId: participant.id,
+      participantName: participant.name,
+      participantChurch: participant.church,
+      dateKey,
+      registeredBy,
+      registeredAt: serverTimestamp(),
+    });
+
+    transaction.set(countRef, {
+      workshopId: workshop.id,
+      workshopName: workshop.name,
+      dateKey,
+      count: currentCount + 1,
+      maxRegistrations: workshop.maxRegistrationsPerDay,
+    });
+  });
+}
+
+export async function deregisterParticipantFromWorkshop({
+  eventId,
+  registration,
+}: {
+  eventId: string;
+  registration: WorkshopRegistration;
+}) {
+  const registrationRef = doc(db, 'events', eventId, 'workshopRegistrations', registration.id);
+  const countRef = doc(
+    db,
+    'events',
+    eventId,
+    'workshopDailyCounts',
+    buildWorkshopDailyCountId(registration.workshopId, registration.dateKey)
+  );
+
+  await runTransaction(db, async (transaction) => {
+    const registrationSnap = await transaction.get(registrationRef);
+    if (!registrationSnap.exists()) {
+      throw new Error('Registration no longer exists.');
+    }
+
+    const countSnap = await transaction.get(countRef);
+    const currentCount = countSnap.exists() ? (countSnap.data().count as number) : 0;
+
+    transaction.delete(registrationRef);
+
+    if (currentCount <= 1) {
+      transaction.delete(countRef);
+    } else {
+      transaction.update(countRef, { count: currentCount - 1 });
+    }
+  });
+}
+
+export async function clearWorkshopRegistrations(eventId: string) {
+  const registrationsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopRegistrations'));
+  const countsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopDailyCounts'));
+
+  let batch = writeBatch(db);
+  let operationCount = 0;
+
+  const commitBatch = async () => {
+    if (operationCount === 0) {
+      return;
+    }
+
+    await batch.commit();
+    batch = writeBatch(db);
+    operationCount = 0;
+  };
+
+  for (const docSnap of registrationsSnapshot.docs) {
+    batch.delete(docSnap.ref);
+    operationCount++;
+    if (operationCount >= 450) {
+      await commitBatch();
+    }
+  }
+
+  for (const docSnap of countsSnapshot.docs) {
+    batch.delete(docSnap.ref);
+    operationCount++;
+    if (operationCount >= 450) {
+      await commitBatch();
+    }
+  }
+
+  await commitBatch();
+}
+
+export function getDefaultWorkshopDateKey(workshops: Workshop[], today = new Date()) {
+  const upcomingKeys = Array.from(
+    new Set(
+      workshops.flatMap((workshop) => {
+        if (!workshop.active) {
+          return [];
+        }
+        const start = workshop.availableFrom;
+        const end = workshop.availableTo;
+        const keys: string[] = [];
+        for (let cursor = new Date(start); cursor <= end; cursor.setDate(cursor.getDate() + 1)) {
+          const current = new Date(cursor);
+          if (current >= new Date(today.getFullYear(), today.getMonth(), today.getDate())) {
+            keys.push(formatDateKey(current));
+          }
+        }
+        return keys;
+      })
+    )
+  ).sort();
+
+  return upcomingKeys[0] || '';
+}
+
+export async function getWorkshopRegistrationsByDate(eventId: string, dateKey: string): Promise<WorkshopRegistration[]> {
+  const registrationsQuery = query(
+    collection(db, 'events', eventId, 'workshopRegistrations'),
+    where('dateKey', '==', dateKey)
+  );
+  const snapshot = await getDocs(registrationsQuery);
+
+  return snapshot.docs.map((docSnap) => {
+    const data = docSnap.data() as Omit<WorkshopRegistration, 'registeredAt'> & {
+      registeredAt: Timestamp;
+    };
+
+    return {
+      id: docSnap.id,
+      ...data,
+      registeredAt: data.registeredAt.toDate(),
+    };
+  });
+}
+
+export async function getWorkshopDailyCountsByDate(eventId: string, dateKey: string): Promise<WorkshopDailyCount[]> {
+  const countsQuery = query(
+    collection(db, 'events', eventId, 'workshopDailyCounts'),
+    where('dateKey', '==', dateKey)
+  );
+  const snapshot = await getDocs(countsQuery);
+
+  return snapshot.docs.map((docSnap) => ({
+    id: docSnap.id,
+    ...(docSnap.data() as Omit<WorkshopDailyCount, 'id'>),
+  }));
 }
 
 // User related functions

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -785,6 +785,33 @@ export async function updateWorkshop(eventId: string, workshopId: string, update
   await updateDoc(workshopRef, updates);
 }
 
+export async function setWorkshopDateLockForEvent(eventId: string, locked: boolean) {
+  const workshopsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshops'));
+  let batch = writeBatch(db);
+  let operationCount = 0;
+
+  const commitBatch = async () => {
+    if (operationCount === 0) {
+      return;
+    }
+
+    await batch.commit();
+    batch = writeBatch(db);
+    operationCount = 0;
+  };
+
+  for (const workshopDoc of workshopsSnapshot.docs) {
+    batch.update(workshopDoc.ref, { lockRegistrationDateToToday: locked });
+    operationCount++;
+
+    if (operationCount >= 450) {
+      await commitBatch();
+    }
+  }
+
+  await commitBatch();
+}
+
 export async function getWorkshopsByEvent(eventId: string): Promise<Workshop[]> {
   const snapshot = await getDocs(collection(db, 'events', eventId, 'workshops'));
   const workshops: Workshop[] = [];
@@ -801,6 +828,7 @@ export async function getWorkshopsByEvent(eventId: string): Promise<Workshop[]> 
       ...data,
       availableFrom: data.availableFrom.toDate(),
       availableTo: data.availableTo.toDate(),
+      lockRegistrationDateToToday: Boolean(data.lockRegistrationDateToToday),
       createdAt: data.createdAt.toDate(),
     });
   });
@@ -825,6 +853,7 @@ export function subscribeToWorkshopsByEvent(
         ...data,
         availableFrom: data.availableFrom.toDate(),
         availableTo: data.availableTo.toDate(),
+        lockRegistrationDateToToday: Boolean(data.lockRegistrationDateToToday),
         createdAt: data.createdAt.toDate(),
       };
     });
@@ -950,6 +979,7 @@ export async function registerParticipantForWorkshop({
       ...workshopData,
       availableFrom: workshopData.availableFrom.toDate(),
       availableTo: workshopData.availableTo.toDate(),
+      lockRegistrationDateToToday: Boolean(workshopData.lockRegistrationDateToToday),
       createdAt: workshopData.createdAt.toDate(),
     };
 

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -46,8 +46,51 @@ export const deleteParticipantWithLogs = async (eventId: string, participantId: 
   );
   const logsSnapshot = await getDocs(logsQuery);
 
+  const workshopRegistrationsQuery = query(
+    collection(db, 'events', eventId, 'workshopRegistrations'),
+    where('participantId', '==', participantId)
+  );
+  const workshopRegistrationsSnapshot = await getDocs(workshopRegistrationsQuery);
+
   const batch = writeBatch(db);
   logsSnapshot.forEach((doc) => batch.delete(doc.ref));
+
+  const workshopCountAdjustments = new Map<string, { ref: ReturnType<typeof doc>; decrementBy: number }>();
+
+  for (const registrationDoc of workshopRegistrationsSnapshot.docs) {
+    const registrationData = registrationDoc.data() as {
+      workshopId: string;
+      dateKey: string;
+    };
+
+    batch.delete(registrationDoc.ref);
+
+    const countId = buildWorkshopDailyCountId(registrationData.workshopId, registrationData.dateKey);
+    const countRef = doc(db, 'events', eventId, 'workshopDailyCounts', countId);
+    const existing = workshopCountAdjustments.get(countId);
+
+    if (existing) {
+      existing.decrementBy += 1;
+    } else {
+      workshopCountAdjustments.set(countId, { ref: countRef, decrementBy: 1 });
+    }
+  }
+
+  for (const { ref, decrementBy } of workshopCountAdjustments.values()) {
+    const countSnapshot = await getDoc(ref);
+
+    if (!countSnapshot.exists()) {
+      continue;
+    }
+
+    const currentCount = Number(countSnapshot.data().count || 0);
+
+    if (currentCount <= decrementBy) {
+      batch.delete(ref);
+    } else {
+      batch.update(ref, { count: currentCount - decrementBy });
+    }
+  }
 
   // Delete participant
   const participantRef = doc(db, `events/${eventId}/participants/${participantId}`);
@@ -226,6 +269,27 @@ export const deleteEventWithCascade = async (eventId: string) => {
   await Promise.all(
     participantsSnapshot.docs.map((docSnap) =>
       deleteDoc(doc(db, `events/${eventId}/participants`, docSnap.id))
+    )
+  );
+
+  const workshopsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshops'));
+  await Promise.all(
+    workshopsSnapshot.docs.map((docSnap) =>
+      deleteDoc(doc(db, 'events', eventId, 'workshops', docSnap.id))
+    )
+  );
+
+  const workshopRegistrationsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopRegistrations'));
+  await Promise.all(
+    workshopRegistrationsSnapshot.docs.map((docSnap) =>
+      deleteDoc(doc(db, 'events', eventId, 'workshopRegistrations', docSnap.id))
+    )
+  );
+
+  const workshopDailyCountsSnapshot = await getDocs(collection(db, 'events', eventId, 'workshopDailyCounts'));
+  await Promise.all(
+    workshopDailyCountsSnapshot.docs.map((docSnap) =>
+      deleteDoc(doc(db, 'events', eventId, 'workshopDailyCounts', docSnap.id))
     )
   );
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,7 @@ import { UserRole, Workshop } from '../types';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-export const CURRENT_DATE_REFERENCE = new Date('2026-07-23T12:00:00');
+export const CURRENT_DATE_REFERENCE = new Date('2026-07-24T12:00:00');
 
 // Combine Tailwind classes safely
 export function cn(...inputs: ClassValue[]) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,8 @@
-import { UserRole } from '../types';
+import { UserRole, Workshop } from '../types';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+
+export const CURRENT_DATE_REFERENCE = new Date('2026-07-23T12:00:00');
 
 // Combine Tailwind classes safely
 export function cn(...inputs: ClassValue[]) {
@@ -71,4 +73,62 @@ export function formatDateTime(date: Date): string {
 // Get activity log type badge color
 export function getActivityLogTypeColor(type: 'departure' | 'return'): string {
   return type === 'departure' ? 'bg-amber-100 text-amber-800' : 'bg-green-100 text-green-800';
+}
+
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function parseDateKey(dateKey: string): Date {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+export function isDateWithinRange(date: Date, from: Date, to: Date): boolean {
+  const target = startOfDay(date).getTime();
+  const start = startOfDay(from).getTime();
+  const end = startOfDay(to).getTime();
+  return target >= start && target <= end;
+}
+
+export function getDateKeysInRange(from: Date, to: Date, minDate?: Date): string[] {
+  const start = startOfDay(from);
+  const end = startOfDay(to);
+  const floor = minDate ? startOfDay(minDate) : null;
+  const dates: string[] = [];
+
+  for (let cursor = start; cursor.getTime() <= end.getTime(); cursor = addDays(cursor, 1)) {
+    if (!floor || cursor.getTime() >= floor.getTime()) {
+      dates.push(formatDateKey(cursor));
+    }
+  }
+
+  return dates;
+}
+
+export function getUpcomingWorkshopDateKeys(workshops: Workshop[], today: Date): string[] {
+  return Array.from(
+    new Set(
+      workshops.flatMap((workshop) => {
+        if (!workshop.active) {
+          return [];
+        }
+
+        return getDateKeysInRange(workshop.availableFrom, workshop.availableTo, today);
+      })
+    )
+  ).sort();
 }


### PR DESCRIPTION
This PR adds full workshop support scoped to the active event, including dashboard/menu entry points, admin workshop management, leader/admin workshop registration, and Firestore-backed capacity enforcement per workshop per date.

It introduces:
- Workshop management for admins with workshop name, availability window, daily registration limit, date-lock mode, and cleanup tools
- Workshop registration for leaders and admins with participant autocomplete, live availability by selected date, de-registration, and concurrency-safe capacity checks
- Firestore schema and rules updates for `events/{eventId}/workshops`, `workshopRegistrations`, and `workshopDailyCounts`
- Cascade cleanup so workshop registrations/counts are removed when clearing workshop data or deleting participants/workshops
- A small admin-only manual return action in Event Detail so an admin can confirm-check a participant back into camp if their QR return was missed

Notes:
- Capacity is enforced transactionally to prevent over-registration under concurrent use
- Participant lists are loaded once per page session where appropriate to avoid unnecessary reads
- Workshop registration cleanup and date-locking were added to make testing and live usage safer

Validation:
- User validations in test environment