### PR TITLE
Add per-date "Copy registrations" button to Workshop Registrations page

### DIFF
--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { Copy, RefreshCw } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 import AuthGuard from '../components/AuthGuard';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
@@ -258,6 +258,36 @@ const WorkshopRegistrations: React.FC = () => {
     }
 
     setPendingWorkshopSwitch(null);
+  };
+
+  const copyRegistrationsForDate = async (dateKey: string) => {
+    const registrationsByWorkshop = allRegistrations
+      .filter((registration) => registration.dateKey === dateKey)
+      .reduce<Record<string, { name: string; registrations: WorkshopRegistration[] }>>((accumulator, registration) => {
+        accumulator[registration.workshopId] = accumulator[registration.workshopId] || {
+          name: registration.workshopName,
+          registrations: [],
+        };
+        accumulator[registration.workshopId].registrations.push(registration);
+        return accumulator;
+      }, {});
+    const text = Object.values(registrationsByWorkshop)
+      .sort((first, second) => first.name.localeCompare(second.name))
+      .map((workshop) => [
+        workshop.name,
+        ...workshop.registrations
+          .sort((first, second) => first.participantName.localeCompare(second.participantName))
+          .map((registration) => `${registration.participantName} - ${registration.participantChurch}`),
+      ].join('\n'))
+      .join('\n\n');
+
+    try {
+      await navigator.clipboard.writeText(text);
+      showMessage('Registrations copied to clipboard.', 'success');
+    } catch (error) {
+      console.error('Error copying workshop registrations:', error);
+      showMessage('Failed to copy registrations.', 'error');
+    }
   };
 
   const handleWorkshopRegistration = async (workshop: Workshop) => {
@@ -548,10 +578,20 @@ const WorkshopRegistrations: React.FC = () => {
                 <div className="space-y-4">
                   {registrationGroupsByDate.map((dateGroup) => (
                     <div key={dateGroup.dateKey} className="rounded-md border border-gray-200 bg-white">
-                      <div className="border-b border-gray-200 px-4 py-3">
+                      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
                         <h3 className="font-medium text-gray-900">
                           {formatDateWithWeekday(parseDateKey(dateGroup.dateKey))}
                         </h3>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 px-2"
+                          title="Copy registrations for this date"
+                          aria-label={`Copy registrations for ${formatDateWithWeekday(parseDateKey(dateGroup.dateKey))}`}
+                          onClick={() => copyRegistrationsForDate(dateGroup.dateKey)}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
                       </div>
                       <div className="space-y-4 p-3">
                         {dateGroup.workshops.map((group) => (


### PR DESCRIPTION
### Motivation

- Provide an easy way for admins to copy all workshop registrations for a given date to the clipboard for sharing or offline use.

### Description

- Imported the `Copy` icon from `lucide-react` and added a small ghost `Button` to each date header to trigger copying.
- Implemented `copyRegistrationsForDate` which groups registrations by workshop for a given `dateKey`, formats the output as text, and writes it to the clipboard using `navigator.clipboard.writeText` with error handling and `showMessage` notifications.
- Adjusted the date header container to use `flex`/`justify-between` so the new copy button is aligned next to the date title.

### Testing

- Ran the TypeScript typecheck which completed successfully.
- Executed the existing automated unit test suite which passed without failures.
- Ran linting/format checks which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67a94782cc8320a83712b3e18a7c37)