### PR TITLE
Filter "Students without registrations" clipboard list to students only

### DIFF
--- a/src/pages/WorkshopRegistrations.tsx
+++ b/src/pages/WorkshopRegistrations.tsx
@@ -298,7 +298,7 @@ const WorkshopRegistrations: React.FC = () => {
         .map((registration) => registration.participantId)
     );
     const participantsWithoutRegistrations = participants.filter(
-      (participant) => !registeredParticipantIds.has(participant.id)
+      (participant) => participant.type === 'student' && !registeredParticipantIds.has(participant.id)
     );
     const text = participantsWithoutRegistrations
       .map((participant) => `${participant.name} - ${participant.church}`)


### PR DESCRIPTION
### Motivation
- Ensure the "Students without registrations" clipboard action copies only participants whose `type` is `student` and not leaders, while still excluding anyone already registered for the selected date.

### Description
- Update `src/pages/WorkshopRegistrations.tsx` to change the participants filter to `participant.type === 'student' && !registeredParticipantIds.has(participant.id)` so only student participants without registrations are copied to the clipboard.

### Testing
- `git diff --check` passed and the working tree is clean after the change.
- `npm run lint` and `npm run build` could not be completed because project dependencies are unavailable in the environment.
- `npm ci` failed due to a `403 Forbidden` response from the npm registry, so dependency installation and full build verification were not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68f6b146fc8320904b1e98eddd76ab)